### PR TITLE
Make private field in Shared Rifffs optional

### DIFF
--- a/src/r3.endlesss/endlesss/api.h
+++ b/src/r3.endlesss/endlesss/api.h
@@ -903,7 +903,7 @@ struct SharedRiffsByUser
                    , CEREAL_NVP( loops )
                    , CEREAL_OPTIONAL_NVP( image_url )
                    , CEREAL_NVP( image )
-                   , cereal::make_nvp( "private", is_private )
+                   , cereal::make_optional_nvp( "private", is_private )
             );
         }
     };


### PR DESCRIPTION
Some really old shared Rifffs didn't have this field yet. Did some testing fetching other people's shared Rifffs and didn't seem to break anything. **This was easy to find thanks to your well implemented logging**